### PR TITLE
Add new arch loongarch64, loongarch64 no test smdev memory

### DIFF
--- a/tests/smdev_test_memory.h
+++ b/tests/smdev_test_memory.h
@@ -28,7 +28,7 @@
 extern "C" {
 #endif
 
-#if defined( HAVE_GNU_DL_DLSYM ) && defined( __GNUC__ ) && !defined( LIBSMDEV_DLL_IMPORT ) && !defined( __arm__ ) && !defined( __clang__ ) && !defined( __CYGWIN__ ) && !defined( __hppa__ ) && !defined( __mips__ ) && !defined( __riscv ) && !defined( __sparc__ ) && !defined( HAVE_ASAN )
+#if defined( HAVE_GNU_DL_DLSYM ) && defined( __GNUC__ ) && !defined( LIBSMDEV_DLL_IMPORT ) && !defined( __arm__ ) && !defined( __clang__ ) && !defined( __CYGWIN__ ) && !defined( __hppa__ ) && !defined( __mips__ ) && !defined( __riscv ) && !defined( __sparc__ ) && !defined( HAVE_ASAN ) && !defined( __loongarch__ )
 #define HAVE_SMDEV_TEST_MEMORY		1
 #endif
 


### PR DESCRIPTION
Add new arch loongarch64, loongarch64 no test smdev memory. the upstream gnu config has supported

Signed-off-by: zhangjialing <zhangjialing@loongson.cn>